### PR TITLE
resolved broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | [TOR Summer of Privacy](https://trac.torproject.org/projects/tor/wiki/org/TorSoP) | Yes | [timeline](https://trac.torproject.org/projects/tor/wiki/org/TorSoP) |
 | [GSOC](https://developers.google.com/open-source/gsoc/) | Yes | [timeline](https://developers.google.com/open-source/gsoc/timeline)       |
 | [SOCIS](https://socis.esa.int/) | Yes | [timeline](https://socis.esa.int/timeline/)   |
-| [Linux Foundation Networking Internships](https://wiki.lfnetworking.org/display/LN/LF+Networking+Internships) | Yes | [timeline](https://wiki.lfnetworking.org/display/LN/LF+Networking+Internships#LFNetworkingInternships-Typicaltimelineforinternship) |
+| [Linux Foundation Mentorship Internships](https://wiki.lfnetworking.org/display/LN/LFN+Mentorship+Program) | Yes | [timeline](https://wiki.lfnetworking.org/display/LN/LF+Networking+Internships#LFNetworkingInternships-Typicaltimelineforinternship) |
 | [The X.Org Endless Vacation of Code (EVoC)](http://www.x.org/wiki/XorgEVoC/)| Yes |[timeline](https://summerofcode.withgoogle.com/how-it-works/#timeline)     |
 | [DataONE Summer Internship Programme](https://www.dataone.org/internships) | Yes*| [timeline](https://www.dataone.org/internships)  |
 |[Julia Summer of Code](https://julialang.org/soc/ideas-page)|Yes|[timeline](https://julialang.org/soc/guidelines/)|


### PR DESCRIPTION
It resolves issue number #187 .
Linux Foundation Networking Internships has renamed to LFN Mentorship Program. The link has broken. The working link is:
https://wiki.lfnetworking.org/display/LN/LFN+Mentorship+Program


### If you are adding a SoC/WoC, please make sure 
- [x] You have added the SoC/WoC in README.md file in correct table
- [x] You have added the SoC/WoC in index.html in correct table
- [x] ensure Website is tested on a deployment and looks okay

### If you are fixing an issue please add
- [x] fixes issue #issue_number to PR description
